### PR TITLE
Match functions  and  can have a  return type now. Previously unless …

### DIFF
--- a/lib/option.d.ts
+++ b/lib/option.d.ts
@@ -13,8 +13,8 @@ declare module 'optionals' {
         getOrElse(other: T): T;
         orNull(): T;
         match<U>(matcher: {
-            some: (val: T) => U;
-            none: () => U;
+            some: (val: T) => U | void;
+            none: () => U | void;
         }): U;
     }
 
@@ -33,8 +33,8 @@ declare module 'optionals' {
         getOrElse(other: T): T;
         orNull(): T;
         match<U>(matcher: {
-            some: ((val: T) => U);
-            none: (() => U);
+            some: ((val: T) => U | void);
+            none: (() => U | void);
         }): U;
     }
 
@@ -51,8 +51,8 @@ declare module 'optionals' {
         getOrElse(other: T): T;
         orNull(): T;
         match<U>(matcher: {
-            some: ((val: T) => U);
-            none: (() => U);
+            some: ((val: T) => U | void);
+            none: (() => U | void);
         }): U;
     }
 }


### PR DESCRIPTION
…returning a type from those functions, tsc would complain
